### PR TITLE
Defines checks attribute for Molecule class

### DIFF
--- a/cctk/molecule.py
+++ b/cctk/molecule.py
@@ -81,6 +81,7 @@ class Molecule:
         self.name = name
         self.multiplicity = multiplicity
         self.charge = charge
+        self.checks = checks
 
         self.vibrational_modes = list()
 


### PR DESCRIPTION
The [docs page](https://cctk.readthedocs.io/en/latest/_autosummary/cctk.Molecule.html#cctk.Molecule) indicates that `checks` should be an attribute for `cctk.Molecule`. However, the attribute is never initialized.  

```python
>>>> import cctk
>>>> mol = cctk.XYZFile.read_file('sample.xyz').molecule
>>>> mol.checks
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Molecule' object has no attribute 'checks'
```

`checks` should either be initialized (as is the case in this PR) or it should be removed from the docs as an attribute.