### PR TITLE
update orca_file.py for compatibility with orca 5

### DIFF
--- a/cctk/orca_file.py
+++ b/cctk/orca_file.py
@@ -172,22 +172,16 @@ class OrcaFile(File):
                 properties[-1]["frequencies"] = sorted(parse.read_freqs(lines))
 
                 enthalpies = lines.find_parameter("Total Enthalpy", expected_length=5, which_field=3)
-                if len(enthalpies) == 1:
-                    properties[-1]["enthalpy"] = enthalpies[0]
-                elif len(enthalpies) > 1:
-                    raise ValueError(f"unexpected # of enthalpies found!\nenthalpies = {enthalpies}")
+                    properties[-1]["enthalpy"] = enthalpies[-1]
 
                 gibbs = lines.find_parameter("Final Gibbs free", expected_length=7, which_field=5)
-                if len(gibbs) == 1:
-                    properties[-1]["gibbs_free_energy"] = gibbs[0]
-                elif len(gibbs) > 1:
-                    raise ValueError(f"unexpected # of gibbs free energies found!\ngibbs free energies = {enthalpies}")
+                    properties[-1]["gibbs_free_energy"] = gibbs[-1]
 
                 temperature = lines.find_parameter("Temperature", expected_length=4, which_field=2)
-                if len(temperature) == 1 and len(gibbs) > 0:
-                    properties[-1]["temperature"] = temperature[0]
-                    corrected_free_energy = get_corrected_free_energy(gibbs[0], properties[-1]["frequencies"],
-                                                                      frequency_cutoff=100.0, temperature=temperature[0])
+                if len(temperature) > 0 and len(gibbs) > 0:
+                    properties[-1]["temperature"] = temperature[-1]
+                    corrected_free_energy = get_corrected_free_energy(gibbs[-1], properties[-1]["frequencies"],
+                                                                      frequency_cutoff=100.0, temperature=temperature[-1])
                     properties[-1]["quasiharmonic_gibbs_free_energy"] = float(corrected_free_energy)
 
             if OrcaJobType.NMR in job_types:

--- a/cctk/orca_file.py
+++ b/cctk/orca_file.py
@@ -177,7 +177,7 @@ class OrcaFile(File):
                 elif len(enthalpies) > 1:
                     raise ValueError(f"unexpected # of enthalpies found!\nenthalpies = {enthalpies}")
 
-                gibbs = lines.find_parameter("Final Gibbs free enthalpy", expected_length=7, which_field=5)
+                gibbs = lines.find_parameter("Final Gibbs free", expected_length=7, which_field=5)
                 if len(gibbs) == 1:
                     properties[-1]["gibbs_free_energy"] = gibbs[0]
                 elif len(gibbs) > 1:

--- a/cctk/orca_file.py
+++ b/cctk/orca_file.py
@@ -172,10 +172,10 @@ class OrcaFile(File):
                 properties[-1]["frequencies"] = sorted(parse.read_freqs(lines))
 
                 enthalpies = lines.find_parameter("Total Enthalpy", expected_length=5, which_field=3)
-                    properties[-1]["enthalpy"] = enthalpies[-1]
+                properties[-1]["enthalpy"] = enthalpies[-1]
 
                 gibbs = lines.find_parameter("Final Gibbs free", expected_length=7, which_field=5)
-                    properties[-1]["gibbs_free_energy"] = gibbs[-1]
+                properties[-1]["gibbs_free_energy"] = gibbs[-1]
 
                 temperature = lines.find_parameter("Temperature", expected_length=4, which_field=2)
                 if len(temperature) > 0 and len(gibbs) > 0:


### PR DESCRIPTION
Orca 4 prints GFE with "Final Gibbs free enthalpy"
Orca 5 prints GFE with "Final Gibbs free energy"
Modified to search for "Final Gibbs free"
This is the approach taken in AaronTools from the Wheeler group.

The thermodynamics section of a frequency calculations prints "Total Enthalpy" twice. Once under the section ENTHALPY and again in the section GIBBS FREE ENERGY. The check for len(enthalpies) == 1 was causing all frequency jobs from ORCA 5 to error out. Removed this check and defined the enthalpy as the last instance of "Total Enthalpy" (see Trans.out) [Trans.txt](https://github.com/ekwan/cctk/files/10551277/Trans.txt)

Transition state searches that start with a hessian calculation include thermodynamic data for the initial structure and for the final optimized structure. All of the strings related to frequency calcs ("Total Enthalpy", "Final Gibbs free" and "Temperature") are printed twice in the output. This was causing errors for all TS searches due to checks that expect len(enthalpies) == 1, len(gibbs) == 1, and len(temperature) == 1. Removed these checks.  See TS25.out [TS25.txt](https://github.com/ekwan/cctk/files/10551286/TS25.txt)


Note that we can't just set the expected lengths of these lists to simple integers because other job types have multiple frequency calculations. See, for example OAScan2_pt7_11.out, which recalculates the hessian matrix every 5 steps and thus prints "Final Gibbs free energy" four times. [OAScan2_pt7_11.txt](https://github.com/ekwan/cctk/files/10551271/OAScan2_pt7_11.txt)


