### PR TITLE
update scripts begin parsing multi-job orca files

### DIFF
--- a/cctk/parse_orca.py
+++ b/cctk/parse_orca.py
@@ -61,7 +61,7 @@ def split_multiple_inputs(filename):
     start_block = 0
     with open(filename, "r") as lines:
         for idx, line in enumerate(lines):
-            if re.search("COMPOUND JOB \d{1,}", line):
+            if re.search("COMPOUND  JOB \d{1,}", line):
                 output_blocks.append(LazyLineObject(file=filename, start=start_block, end=idx))
                 start_block = idx
     output_blocks.append(LazyLineObject(file=filename, start=start_block, end=idx))

--- a/cctk/parse_orca.py
+++ b/cctk/parse_orca.py
@@ -48,7 +48,7 @@ def read_energies(lines):
 
 def split_multiple_inputs(filename):
     """
-    Splits ``filename`` into blocks by searching for COMPOUND JOB.
+    Splits ``filename`` into blocks by searching for COMPOUND JOB  #.
 
     Args:
         filename (str): path to file
@@ -61,12 +61,12 @@ def split_multiple_inputs(filename):
     start_block = 0
     with open(filename, "r") as lines:
         for idx, line in enumerate(lines):
-            if re.search("COMPOUND JOB", line):
+            if re.search("COMPOUND JOB \d{1,}", line):
                 output_blocks.append(LazyLineObject(file=filename, start=start_block, end=idx))
                 start_block = idx
     output_blocks.append(LazyLineObject(file=filename, start=start_block, end=idx))
 
-    return output_blocks
+    return output_blocks[:]
 
 def read_mulliken_charges(lines):
     """

--- a/cctk/parse_orca.py
+++ b/cctk/parse_orca.py
@@ -48,7 +48,7 @@ def read_energies(lines):
 
 def split_multiple_inputs(filename):
     """
-    Splits ``filename`` into blocks by searching for _________.
+    Splits ``filename`` into blocks by searching for COMPOUND JOB.
 
     Args:
         filename (str): path to file
@@ -61,7 +61,7 @@ def split_multiple_inputs(filename):
     start_block = 0
     with open(filename, "r") as lines:
         for idx, line in enumerate(lines):
-            if re.search("Entering Link 1", line): # this will never be true for an Orca file -- this is just a stopgap
+            if re.search("COMPOUND JOB", line):
                 output_blocks.append(LazyLineObject(file=filename, start=start_block, end=idx))
                 start_block = idx
     output_blocks.append(LazyLineObject(file=filename, start=start_block, end=idx))

--- a/scripts/analyze_orca.py
+++ b/scripts/analyze_orca.py
@@ -71,7 +71,10 @@ else:
 
 df.rename(columns={"rms_displacement": "rms_disp", "quasiharmonic_gibbs_free_energy": "GFE (corrected)"}, inplace=True)
 df["filename"] = df["filename"].apply(lambda x: x[-60:])
-df["GFE (corrected)"] = df["GFE (corrected)"].apply(lambda x: f"{x:.5f}")
+# df["GFE (corrected)"] = df["GFE (corrected)"].apply(lambda x: f"{x:.5f}") 
+# the commented out line above sometimes breaks the script 
+# with error "ValueError: Unknown format code 'f' for object of type 'str'"
+# see /Users/gairj/research/calcs/ORCA/orca_evaluation/testing_space/aws/test01_general_cloud/output
 df["rms_step"] = df["rms_step"].apply(lambda x: f"\033[92m{x}\033[0m" if float(x or 0) < 0.0001 else f"\033[93m{x}\033[0m")
 df["rms_gradient"] = df["rms_gradient"].apply(lambda x: f"\033[92m{x}\033[0m" if float(x or 0) < 0.003 else f"\033[93m{x}\033[0m")
 df["success"] = df["success"].apply(lambda x: f"\033[92m{x}\033[0m" if x else f"\033[93m{x}\033[0m")

--- a/scripts/gen_start_g16.py
+++ b/scripts/gen_start_g16.py
@@ -1,0 +1,9 @@
+import cctk, sys
+
+# this is a script for generating gjf files from molecule names
+# usage: gen_start.py mol_name file_name.gjf
+# example: gen_start_g16.py FK506 fk506.gjf
+
+mol = cctk.Molecule.new_from_name(sys.argv[1])
+cctk.GaussianFile.write_molecule_to_file(sys.argv[2], mol, route_card="#p opt b3lyp/6-31g(d) empiricaldispersion=gd3bj")
+print("done")

--- a/scripts/gen_start_orca.py
+++ b/scripts/gen_start_orca.py
@@ -1,0 +1,17 @@
+import cctk, sys
+
+# this is a script for generating gjf files from molecule names
+# usage: gen_start_orca.py mol_name file_name.inp
+# example: gen_start_orca.py FK506 fk506.inp
+
+mol = cctk.Molecule.new_from_name(sys.argv[1])
+cctk.OrcaFile.write_molecule_to_file(sys.argv[2], mol, 
+	header="! opt b3lyp/G 6-31g(d) D3 Normalprint Printbasis PrintMOs #CPCM",
+	variables={"maxcore": 1000},
+	blocks={"pal": ["nproc 4"] 
+            # , "mdci": ["density none"]
+            # , "cpcm": ["smd true", "SMDsolvent \"dichloromethane\""]
+            # , "scf": ["Print[P_SCFMemInfo] 1"]
+            },
+        )
+print("done")


### PR DESCRIPTION
1. Added scripts for starting g16 and orca jobs from molecule names, gen_start_g16.py and gen_start_orca.py (courtesy of Corin)
2. Edit resubmit.py to accept both orca.out and g16.out files
3. temporary fix in analyze_orca.py to stop it from breaking with some frequency jobs. (need to find a real solution)
4. start work on parse_orca.py to enable analysis of multi-job orca outputs.