### PR TITLE
Fixes invalid escape sequences

### DIFF
--- a/cctk/gaussian_file.py
+++ b/cctk/gaussian_file.py
@@ -544,7 +544,7 @@ class GaussianFile(File):
 
         for idx, line in enumerate(lines):
             if header is None:
-                if re.match("\%", line):
+                if re.match(r"\%", line):
                     pieces = line[1:].split("=")
                     link0[pieces[0]] = pieces[1]
                     continue

--- a/cctk/orca_file.py
+++ b/cctk/orca_file.py
@@ -275,7 +275,7 @@ class OrcaFile(File):
                 pass
 
             try:
-                dipole = lines.find_parameter("Magnitude \(Debye\)", 4, 3)
+                dipole = lines.find_parameter(r"Magnitude \(Debye\)", 4, 3)
                 properties[-1]["dipole_moment"] = dipole[0]
             except Exception:
                 pass

--- a/cctk/parse_gaussian.py
+++ b/cctk/parse_gaussian.py
@@ -425,7 +425,7 @@ def parse_header_footer(route_block, title_block, footer_block, link0_block):
         )
 
     for line in link0_block[0].split("\n"):
-        if re.match(" \%", line):
+        if re.match(r" \%", line):
             pieces = line[2:].split("=")
             link0[pieces[0]] = pieces[1]
 
@@ -844,15 +844,15 @@ def read_nmr_shifts(blocks, num_atoms):
                 shieldings.append(shielding)
 
         # yes, this is very elegant.
-        tensor[0][0] = float(re.search("XX=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[0][1] = float(re.search("XY=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[0][2] = float(re.search("XZ=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[1][0] = float(re.search("YX=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[1][1] = float(re.search("YY=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[1][2] = float(re.search("YZ=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[2][0] = float(re.search("ZX=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[2][1] = float(re.search("ZY=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
-        tensor[2][2] = float(re.search("ZZ=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[0][0] = float(re.search(r"XX=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[0][1] = float(re.search(r"XY=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[0][2] = float(re.search(r"XZ=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[1][0] = float(re.search(r"YX=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[1][1] = float(re.search(r"YY=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[1][2] = float(re.search(r"YZ=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[2][0] = float(re.search(r"ZX=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[2][1] = float(re.search(r"ZY=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
+        tensor[2][2] = float(re.search(r"ZZ=\s+(?P<val>-?\d+\.\d+)", block).group("val"))
         tensors.append(tensor)
 
     if len(shieldings) != 0:

--- a/cctk/parse_orca.py
+++ b/cctk/parse_orca.py
@@ -15,7 +15,7 @@ def read_geometries(lines, num_to_find):
     geometries = []
 
     geom_blocks = lines.search_for_block(
-        "CARTESIAN COORDINATES \(ANGSTROEM\)",
+        r"CARTESIAN COORDINATES \(ANGSTROEM\)",
         "CARTESIAN COORDINATES",
         join="\n",
         count=num_to_find,
@@ -72,7 +72,7 @@ def split_multiple_inputs(filename):
     start_block = 0
     with open(filename, "r") as lines:
         for idx, line in enumerate(lines):
-            if re.search("COMPOUND JOB  \d{1,}", line):
+            if re.search(r"COMPOUND JOB  \d{1,}", line):
                 output_blocks.append(
                     LazyLineObject(file=filename, start=start_block, end=idx)
                 )
@@ -189,7 +189,7 @@ def read_blocks_and_variables(lines):
 
 def extract_input_file(lines):
     input_block = lines.search_for_block(
-        "INPUT FILE", "\*\*\*\*END OF INPUT\*\*\*\*", join="\n"
+        r"INPUT FILE", "\*\*\*\*END OF INPUT\*\*\*\*", join="\n"
     )
     input_lines = []
     for line in input_block.split("\n")[3:]:
@@ -234,7 +234,7 @@ def read_freqs(lines, successful_freq):
 
 def read_gradients(lines, num_to_find):
     grad_blocks = lines.search_for_block(
-        "Geometry convergence", "Max\(Bonds", join="\n", count=num_to_find
+        r"Geometry convergence", "Max\(Bonds", join="\n", count=num_to_find
     )
     if grad_blocks is None:
         return


### PR DESCRIPTION
Python 3.12 starts throwing `SyntaxWarning` when using non-raw strings with invalid escape sequences.